### PR TITLE
fix: use persistent service entry point for match-list-processor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     #   context: local-patches/match-list-processor
     #   dockerfile: Dockerfile.patched
     container_name: match-list-processor
+    command: ["python", "-m", "src.app_persistent"]  # Use persistent service mode to prevent restart loop
     environment:
       - FOGIS_API_CLIENT_URL=http://fogis-api-client-service:8080
       - CALENDAR_SYNC_URL=http://fogis-calendar-phonebook-sync:5003/sync
@@ -87,8 +88,8 @@ services:
       - GOOGLE_DRIVE_URL=http://google-drive-service:5000
       - LOG_LEVEL=INFO
       - FORCE_FRESH_PROCESSING=false  # Disable for event-driven processing
-      - RUN_MODE=service              # Run as persistent service waiting for webhooks
-      - SERVICE_INTERVAL=3600         # Fallback interval (1 hour) for health checks only
+      - RUN_MODE=service              # Run as persistent service with periodic processing
+      - SERVICE_INTERVAL=3600         # Processing interval (1 hour) between match checks
     volumes:
       - ./data/match-list-processor:/app/data
       - ./logs/match-list-processor:/app/logs


### PR DESCRIPTION
## Problem

The match-list-processor service was experiencing a **restart loop issue** during deployment migration testing. The service would:

1. Start successfully
2. Process matches and complete the task
3. Exit normally (as designed for oneshot mode)
4. Get restarted by Docker due to `restart: unless-stopped` policy
5. Repeat the cycle indefinitely

## Root Cause

The issue was a **configuration mismatch** between:
- **Environment variables**: `RUN_MODE=service` (indicating persistent service mode)
- **Container entry point**: Used default `src.app` (oneshot mode that exits after processing)

## Solution

This PR implements an **immediate deployment fix** by explicitly using the persistent service entry point:

### Changes Made

```yaml
match-list-processor:
  # Add explicit command to use persistent service mode
  command: ["python", "-m", "src.app_persistent"]
  environment:
    - RUN_MODE=service              # Run as persistent service with periodic processing
    - SERVICE_INTERVAL=3600         # Processing interval (1 hour) between match checks
```

### Key Improvements

1. **Explicit Entry Point**: Forces use of `src.app_persistent` regardless of container default
2. **Updated Comments**: Clarified environment variable purposes
3. **Immediate Fix**: Works with current container images without waiting for new builds

## Testing Results

✅ **Local Testing Confirmed**:
- Service starts and runs continuously
- No restart loops observed
- Health checks pass consistently
- Logs show: `"Match processing cycle completed. Sleeping for 3600s..."`
- Container status: `Up X minutes (healthy)` (stable)

✅ **Before Fix**:
```
NAMES                  STATUS
match-list-processor   Restarting (0) 3 seconds ago
```

✅ **After Fix**:
```
NAMES                  STATUS
match-list-processor   Up 20 seconds (healthy)
```

## Service Behavior

**Previous (Oneshot Mode)**:
```
1. Start → Process matches → Exit → Docker restarts → Loop
```

**Current (Persistent Service Mode)**:
```
1. Start → Process matches → Sleep 3600s → Process again → Continue indefinitely
```

## Deployment Impact

- ✅ **Immediate**: Can be deployed right now with existing container images
- ✅ **Safe**: No breaking changes, maintains all existing functionality
- ✅ **Stable**: Eliminates resource waste from constant container restarts
- ✅ **Monitoring**: Health endpoints remain available continuously

## Related Work

This PR works in conjunction with [PitchConnect/match-list-processor#21](https://github.com/PitchConnect/match-list-processor/pull/21) which implements a smart entry point in the service repository. Together, they provide:

- **Short-term**: This deployment fix (immediate resolution)
- **Long-term**: Smart entry point in container (future-proof solution)

## Migration Testing Context

This fix was identified during comprehensive FOGIS deployment migration testing where we validated backup/restoration procedures. The restart loop was the only critical issue preventing full system stability, and this change resolves it completely.

---

**Priority**: High - Resolves critical production stability issue
**Risk**: Low - Tested locally with confirmed stable operation
**Rollback**: Simple - revert the command override if needed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author