### PR TITLE
fix: Create .env file for docker compose config validation in CI

### DIFF
--- a/.github/workflows/nightly-deployment-validation.yml
+++ b/.github/workflows/nightly-deployment-validation.yml
@@ -59,6 +59,26 @@ jobs:
       - name: Validate Docker Compose syntax
         run: |
           echo "🔍 Validating Docker Compose configuration..."
+
+          # Create a minimal .env file for validation (docker-compose.yml requires it)
+          # This file is not committed to the repository (it's in .gitignore)
+          cat > .env << 'EOF'
+          # Minimal .env file for CI validation
+          FOGIS_USERNAME=ci_test_user
+          FOGIS_PASSWORD=ci_test_password
+          NOTIFICATIONS_ENABLED=false
+          EMAIL_ENABLED=false
+          SMTP_HOST=smtp.example.com
+          SMTP_PORT=587
+          SMTP_USERNAME=test@example.com
+          SMTP_PASSWORD=test_password
+          SMTP_FROM=noreply@example.com
+          SMTP_USE_TLS=true
+          DISCORD_ENABLED=false
+          DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/test
+          DISCORD_BOT_USERNAME=FOGIS Bot
+          EOF
+
           docker compose -f docker-compose.yml config --quiet
           echo "✅ Docker Compose syntax is valid"
 
@@ -296,6 +316,23 @@ jobs:
       - name: Scan Docker Compose for security issues
         run: |
           echo "🔍 Scanning Docker Compose for security misconfigurations..."
+
+          # Create a minimal .env file for validation (docker-compose.yml requires it)
+          cat > .env << 'EOF'
+          FOGIS_USERNAME=ci_test_user
+          FOGIS_PASSWORD=ci_test_password
+          NOTIFICATIONS_ENABLED=false
+          EMAIL_ENABLED=false
+          SMTP_HOST=smtp.example.com
+          SMTP_PORT=587
+          SMTP_USERNAME=test@example.com
+          SMTP_PASSWORD=test_password
+          SMTP_FROM=noreply@example.com
+          SMTP_USE_TLS=true
+          DISCORD_ENABLED=false
+          DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/test
+          DISCORD_BOT_USERNAME=FOGIS Bot
+          EOF
 
           # Check for privileged containers
           if docker compose -f docker-compose.yml config | grep -q "privileged: true"; then


### PR DESCRIPTION
## Problem

After merging PR #86 (Docker Compose v2 syntax fix), the nightly deployment validation workflow is still failing, but with a **different error**:

**Previous error (FIXED ✅):**
```
docker-compose: command not found
Process completed with exit code 127
```

**New error:**
```
env file /home/runner/work/fogis-deployment/fogis-deployment/.env not found: stat .env: no such file or directory
Process completed with exit code 1
```

**Failed workflow run:** https://github.com/PitchConnect/fogis-deployment/actions/runs/18304500107/job/52118670047

## Root Cause

The `docker-compose.yml` file has an `env_file` directive that requires a `.env` file:

```yaml
x-env-file: &env-file
  env_file:
    - .env
```

The `.env` file is in `.gitignore` (correctly, as it contains sensitive credentials), so it doesn't exist in the CI environment. When `docker compose config` runs, it fails because it can't find the required `.env` file.

## Solution

This PR creates a minimal `.env` file with placeholder values before running `docker compose config` commands in CI. This allows the validation to succeed without exposing any real credentials.

### Changes Made

1. **Updated `validate-configurations` job** (lines 59-83):
   - Added `.env` file creation before `docker compose config`
   - Uses minimal placeholder values for all required environment variables

2. **Updated `security-scanning` job** (lines 316-351):
   - Added `.env` file creation before `docker compose config`
   - Uses same placeholder values for consistency

3. **No changes needed for `deployment-smoke-test` job**:
   - Already creates a `.env` file (lines 465-478)

### Environment Variables Included

```bash
FOGIS_USERNAME=ci_test_user
FOGIS_PASSWORD=ci_test_password
NOTIFICATIONS_ENABLED=false
EMAIL_ENABLED=false
SMTP_HOST=smtp.example.com
SMTP_PORT=587
SMTP_USERNAME=test@example.com
SMTP_PASSWORD=test_password
SMTP_FROM=noreply@example.com
SMTP_USE_TLS=true
DISCORD_ENABLED=false
DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/test
DISCORD_BOT_USERNAME=FOGIS Bot
```

## Testing

This fix will be validated by:
1. Running the nightly deployment validation workflow
2. Verifying that `docker compose config` succeeds in both jobs
3. Confirming no "env file not found" errors

## Impact

- ✅ Completes the Docker Compose v2 migration
- ✅ Allows `docker compose config` to run successfully in CI
- ✅ Maintains security by not committing real credentials
- ✅ Uses placeholder values that are clearly for testing only

## Related Issues

- Follows up on PR #86 (Docker Compose v2 syntax fix)
- Fixes workflow run failure: https://github.com/PitchConnect/fogis-deployment/actions/runs/18304500107

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author