### PR TITLE
fix: Skip integration tests when not available in repository

### DIFF
--- a/.github/workflows/nightly-deployment-validation.yml
+++ b/.github/workflows/nightly-deployment-validation.yml
@@ -410,12 +410,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check if integration tests exist
+        id: check-tests
+        run: |
+          if [ -f "tests/integration/requirements.txt" ] && [ -f "tests/run_integration_tests.sh" ]; then
+            echo "tests_exist=true" >> $GITHUB_OUTPUT
+            echo "✅ Integration tests found"
+          else
+            echo "tests_exist=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Integration tests not found in repository (excluded by .gitignore)"
+            echo "Skipping integration tests..."
+          fi
+
       - name: Set up Python
+        if: steps.check-tests.outputs.tests_exist == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install test dependencies
+        if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
           echo "📦 Installing integration test dependencies..."
           python -m pip install --upgrade pip
@@ -423,6 +437,7 @@ jobs:
           echo "✅ Dependencies installed"
 
       - name: Run integration tests
+        if: steps.check-tests.outputs.tests_exist == 'true'
         id: run-tests
         run: |
           echo "🧪 Running integration test suite..."
@@ -431,7 +446,7 @@ jobs:
           echo "✅ Integration tests completed"
 
       - name: Upload test reports
-        if: always()
+        if: always() && steps.check-tests.outputs.tests_exist == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-reports
@@ -442,7 +457,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload test logs on failure
-        if: failure()
+        if: failure() && steps.check-tests.outputs.tests_exist == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-logs


### PR DESCRIPTION
## Problem

The nightly deployment validation workflow is failing at the `integration-tests` job with:

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'tests/integration/requirements.txt'
Process completed with exit code 1
```

**Failed workflow run:** https://github.com/PitchConnect/fogis-deployment/actions/runs/18305991391/job/52123280629

## Root Cause Analysis

### Investigation Findings:

1. **The `tests/integration/` directory exists locally** but is **NOT in the git repository**

2. **The `.gitignore` file excludes integration tests** (line 239):
   ```gitignore
   # Development and testing artifacts
   deployment-improvements/
   tools/
   stacks/
   pr_descriptions/
   tests/unit/
   tests/e2e/
   tests/integration/  # <-- This line excludes the entire directory
   ```

3. **This was intentional** - The tests were excluded in commit `4d1020e` ("Comprehensive repository cleanup for Redis pub/sub transition")

4. **The workflow assumes tests exist** and tries to:
   - Install dependencies from `tests/integration/requirements.txt`
   - Run `tests/run_integration_tests.sh`
   - Both files are excluded from the repository

### Why This Happened:

The nightly deployment validation workflow was created with an `integration-tests` job that references test files that are intentionally excluded from the repository. This creates a mismatch between what the workflow expects and what's actually in the repository.

## Solution

This PR makes the integration tests **conditional** - they will only run if the test files exist in the repository. This allows the workflow to:

1. **Gracefully skip** integration tests when they're not available (current state)
2. **Automatically run** integration tests if they're ever added back to the repository
3. **Provide clear feedback** about why tests are being skipped

### Changes Made

1. **Added a check step** to verify if integration tests exist:
   ```yaml
   - name: Check if integration tests exist
     id: check-tests
     run: |
       if [ -f "tests/integration/requirements.txt" ] && [ -f "tests/run_integration_tests.sh" ]; then
         echo "tests_exist=true" >> $GITHUB_OUTPUT
         echo "✅ Integration tests found"
       else
         echo "tests_exist=false" >> $GITHUB_OUTPUT
         echo "⚠️ Integration tests not found in repository (excluded by .gitignore)"
         echo "Skipping integration tests..."
       fi
   ```

2. **Made all test steps conditional** on `steps.check-tests.outputs.tests_exist == 'true'`:
   - Set up Python
   - Install test dependencies
   - Run integration tests
   - Upload test reports
   - Upload test logs

3. **Preserved existing behavior** for when tests are available:
   - All test functionality remains unchanged
   - Artifact uploads still work correctly
   - Error handling is preserved

## Testing

With this fix:
- ✅ The workflow will skip integration tests gracefully (current state)
- ✅ A clear message will be logged explaining why tests are skipped
- ✅ The job will succeed instead of failing
- ✅ If tests are ever added back, they will run automatically

## Impact

- ✅ Fixes the "requirements file not found" error
- ✅ Allows the nightly deployment validation workflow to complete successfully
- ✅ Provides flexibility for future integration test additions
- ✅ Maintains backward compatibility if tests are restored

## Alternative Approaches Considered

1. **Remove integration tests from `.gitignore`** and commit them
   - ❌ Would reverse the intentional cleanup from commit `4d1020e`
   - ❌ May add unwanted files back to the repository

2. **Remove the integration-tests job entirely**
   - ❌ Would lose the ability to run tests if they're added later
   - ❌ Less flexible than conditional execution

3. **Make the job conditional** (chosen approach)
   - ✅ Gracefully handles current state
   - ✅ Automatically adapts if tests are added
   - ✅ Provides clear feedback

## Related Issues

- Follows up on PR #88 (.env file fix)
- Fixes workflow run failure: https://github.com/PitchConnect/fogis-deployment/actions/runs/18305991391

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author